### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
 	<extension>
-		<groupId>org.eclipse.tycho.extras</groupId>
-		<artifactId>tycho-pomless</artifactId>
-		<version>2.4.0</version>
-	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>2.7.5</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.8.9</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.simulizar.power</groupId>
 	<artifactId>parent</artifactId>	
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
-		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.simulizar.power.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.simulizar.power.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	
 	<modules>

--- a/releng/org.palladiosimulator.simulizar.power.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.simulizar.power.targetplatform/tp.target
@@ -1,274 +1,127 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="org.palladiosimulator.simulizar.power Target Platform" sequenceNumber="1">
-<locations>
-   	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simucom/releases/latest/"/>
-		<unit id="org.palladiosimulator.simucom.feature.feature.group" version="0.0.0"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simucom/nightly/"/>
-		<unit id="org.palladiosimulator.simucom.feature.feature.group" version="0.0.0"/>
-	</location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
-        <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
-        <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/latest/"/>
-        <unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
-        <unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-framework/releases/latest/"/>
-        <unit id="org.palladiosimulator.analyzer.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-framework/nightly/"/>
-        <unit id="org.palladiosimulator.analyzer.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/releases/latest/"/>
-        <unit id="de.uka.ipd.sdq.workflow.feature.core.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/nightly/"/>
-        <unit id="de.uka.ipd.sdq.workflow.feature.core.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-featuremodel/releases/latest"/>
-        <unit id="de.uka.ipd.sdq.featureconfig" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-featuremodel/nightly/"/>
-        <unit id="de.uka.ipd.sdq.featureconfig" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/releases/latest/"/>
-        <unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
-        <unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/releases/latest"/>
-        <unit id="org.palladiosimulator.edp2.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/nightly/"/>
-        <unit id="org.palladiosimulator.edp2.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/releases/latest/"/>
-        <unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
-        <unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/releases/latest/"/>
-        <unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
-        <unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/releases/latest/"/>
-        <unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
-        <unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-reliability/releases/latest/"/>
-        <unit id="org.palladiosimulator.reliability.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-reliability/nightly/"/>
-        <unit id="org.palladiosimulator.reliability.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-solver/releases/latest/"/>
-        <unit id="org.palladiosimulator.solver.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-solver/nightly/"/>
-        <unit id="org.palladiosimulator.solver.feature.feature.group" version="0.0.0"/>
-    </location>
-
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-qual-probeframework/releases/latest/"/>
-		<unit id="org.palladiosimulator.probeframework.feature.feature.group" version="0.0.0"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-qual-probeframework/nightly/"/>
-		<unit id="org.palladiosimulator.probeframework.feature.feature.group" version="0.0.0"/>
-	</location>
-
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-recorderframework/releases/latest/"/>
-        <unit id="org.palladiosimulator.recorderframework.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-recorderframework/nightly/"/>
-        <unit id="org.palladiosimulator.recorderframework.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-sensorframework/releases/latest/"/>
-        <unit id="de.uka.ipd.sdq.sensorframework.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-sensorframework/nightly/"/>
-        <unit id="de.uka.ipd.sdq.sensorframework.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/releases/latest/"/>
-        <unit id="de.uka.ipd.sdq.simulation.abstractsimengine.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/nightly/"/>
-        <unit id="de.uka.ipd.sdq.simulation.abstractsimengine.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-simulation-scheduler/releases/latest/"/>
-        <unit id="org.palladiosimulator.scheduler.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-simulation-scheduler/nightly/"/>
-        <unit id="org.palladiosimulator.scheduler.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-experimentanalysis/releases/latest/"/>
-        <unit id="org.palladiosimulator.experimentanalysis.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-experimentanalysis/nightly/"/>
-        <unit id="org.palladiosimulator.experimentanalysis.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-limbo/nightly/"/>
-		<unit id="tools.descartes.dlim.feature.feature.group" version="0.0.0"/>
-	</location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simulizar/releases/latest/"/>
-        <unit id="org.palladiosimulator.simulizar.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simulizar/nightly/"/>
-        <unit id="org.palladiosimulator.simulizar.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-monitorrepository/releases/latest/"/>
-        <unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-qual-monitorrepository/nightly/"/>
-        <unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-cloudscaleusageevolution/releases/latest/"/>
-        <unit id="org.scaledl.usageevolution.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-cloudscaleusageevolution/nightly/"/>
-        <unit id="org.scaledl.usageevolution.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-addons-servicelevelobjectives/releases/latest/"/>
-        <unit id="org.palladiosimulator.servicelevelobjective.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-addons-servicelevelobjectives/nightly/"/>
-        <unit id="org.palladiosimulator.servicelevelobjective.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/releases/latest/"/>
-        <unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
-        <unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/latest/"/>
-        <unit id="org.modelversioning.emfprofile.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
-        <unit id="org.modelversioning.emfprofile.feature.feature.group" version="0.0.0"/>
-    </location>
-
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly">
-        <repository location="https://updatesite.mdsd.tools/library-emfeditutils/nightly/"/>
-        <unit id="tools.mdsd.library.emfeditutils.feature.feature.group" version="0.0.0"/>
-    </location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release">
-		<repository location="https://updatesite.mdsd.tools/library-emfeditutils/releases/latest/"/>
-		<unit id="tools.mdsd.library.emfeditutils.feature.feature.group" version="0.0.0"/>
-	</location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.mdsd.tools/thirdparty-library/releases/latest/"/>
-        <unit id="com.google.auto.factory-annotations.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.mdsd.tools/thirdparty-library/nightly"/>
-        <unit id="com.google.auto.factory-annotations.feature.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/releases/latest/"/>
-        <unit id="org.jscience.feature.feature.group" version="0.0.0"/>
-        <unit id="org.jscience.feature.source.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly"/>
-        <unit id="org.jscience.feature.feature.group" version="0.0.0"/>
-        <unit id="org.jscience.feature.source.feature.group" version="0.0.0"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-addons-power/releases/latest/"/>
-        <unit id="de.fzi.power.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.palladio-simulator.com/palladio-addons-power/nightly/"/>
-        <unit id="de.fzi.power.feature.feature.group" version="0.0.0"/>
-    </location>
-
-</locations>
+<?pde version="3.8"?><target name="org.palladiosimulator.simulizar.power Target Platform" sequenceNumber="2">
+	<locations>
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simucom/nightly/"/>
+			<unit id="org.palladiosimulator.simucom.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
+			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-framework/nightly/"/>
+			<unit id="org.palladiosimulator.analyzer.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/nightly/"/>
+			<unit id="de.uka.ipd.sdq.workflow.feature.core.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-featuremodel/nightly/"/>
+			<unit id="de.uka.ipd.sdq.featureconfig" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
+			<unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/nightly/"/>
+			<unit id="org.palladiosimulator.edp2.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
+			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
+			<unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
+			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-reliability/nightly/"/>
+			<unit id="org.palladiosimulator.reliability.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-solver/nightly/"/>
+			<unit id="org.palladiosimulator.solver.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-probeframework/nightly/"/>
+			<unit id="org.palladiosimulator.probeframework.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-recorderframework/nightly/"/>
+			<unit id="org.palladiosimulator.recorderframework.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-sensorframework/nightly/"/>
+			<unit id="de.uka.ipd.sdq.sensorframework.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/nightly/"/>
+			<unit id="de.uka.ipd.sdq.simulation.abstractsimengine.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-scheduler/nightly/"/>
+			<unit id="org.palladiosimulator.scheduler.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-experimentanalysis/nightly/"/>
+			<unit id="org.palladiosimulator.experimentanalysis.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-limbo/nightly/"/>
+			<unit id="tools.descartes.dlim.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simulizar/nightly/"/>
+			<unit id="org.palladiosimulator.simulizar.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-monitorrepository/nightly/"/>
+			<unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-cloudscaleusageevolution/nightly/"/>
+			<unit id="org.scaledl.usageevolution.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-servicelevelobjectives/nightly/"/>
+			<unit id="org.palladiosimulator.servicelevelobjective.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
+			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
+			<unit id="org.modelversioning.emfprofile.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.mdsd.tools/library-emfeditutils/nightly/"/>
+			<unit id="tools.mdsd.library.emfeditutils.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.mdsd.tools/thirdparty-library/nightly"/>
+			<unit id="com.google.auto.factory-annotations.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly"/>
+			<unit id="org.jscience.feature.feature.group" version="0.0.0"/>
+			<unit id="org.jscience.feature.source.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-power/nightly/"/>
+			<unit id="de.fzi.power.feature.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
 </target>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.8.9` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.8.9` to `0.10.0`
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`
  - Switched from `tycho-pomless:2.4.0` to `tycho-build:2.7.5`
- In the target platform `tp.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:
    - Removed any `<location filter="release">` entries
    - Removed `filter="nightly"` attributes
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`